### PR TITLE
Handle classes being used for DependencyKey's

### DIFF
--- a/Sources/ComposableEnvironment/Internal/AnyHashableType.swift
+++ b/Sources/ComposableEnvironment/Internal/AnyHashableType.swift
@@ -5,8 +5,15 @@ struct AnyHashableType: Hashable {
 
   init<T>(_ type: T.Type) {
     self.type = type
-    isEqualTo = { $0.type is T.Type }
-    hashInto = { $0.combine(String(describing: T.self)) }
+    let description = String(describing: T.self)
+    if type is AnyClass {
+      // We can't compare types with `is` for classes as B:A is A.
+      // Fallback to the description which is also used to hash.
+      isEqualTo = { description == String(describing: $0.type) }
+    } else {
+      isEqualTo = { $0.type is T.Type }
+    }
+    hashInto = { $0.combine(description) }
   }
 
   func hash(into hasher: inout Hasher) {

--- a/Tests/ComposableEnvironmentTests/AnyHashableTypeTests.swift
+++ b/Tests/ComposableEnvironmentTests/AnyHashableTypeTests.swift
@@ -1,0 +1,22 @@
+@testable import ComposableEnvironment
+import XCTest
+
+final class AnyHashableTypeTests: XCTestCase {
+  func testTypeComparison() {
+    XCTAssertEqual(AnyHashableType(Int.self), AnyHashableType(Int.self))
+    XCTAssertNotEqual(AnyHashableType(String.self), AnyHashableType(Int.self))
+  }
+  
+  func testTypeComparisonWithGenerics() {
+    struct Generic<T> {}
+    XCTAssertEqual(AnyHashableType(Generic<Int>.self), AnyHashableType(Generic<Int>.self))
+    XCTAssertNotEqual(AnyHashableType(Generic<String>.self), AnyHashableType(Generic<Int>.self))
+  }
+  
+  func testTypeComparisonWithClasses() {
+    class A {}
+    class B: A {}
+    XCTAssertEqual(AnyHashableType(A.self), AnyHashableType(A.self))
+    XCTAssertNotEqual(AnyHashableType(A.self), AnyHashableType(B.self))
+  }
+}


### PR DESCRIPTION
The preferred way is still using a struct or an inhabited enum.