### PR TITLE
Build "Documentation" only on `main`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,7 +1,10 @@
 # .github/workflows/documentation.yml
 name: Documentation
 
-on: [push]
+on:
+   push:
+     branches:
+       - main
 
 jobs:
   build:


### PR DESCRIPTION
Otherwise, WIP branches may overwrite the wiki