### PR TITLE
Add migration helpers

### DIFF
--- a/Sources/ComposableEnvironment/Deprecations/GlobalEnvironment+Migration.swift
+++ b/Sources/ComposableEnvironment/Deprecations/GlobalEnvironment+Migration.swift
@@ -1,0 +1,29 @@
+@available(*, deprecated, message: """
+  If you are transitioning from `GlobalEnvironment`, you should make sure that is type is a \
+  subclass of `ComposableEnvironment`.
+  
+  If your environment is a `struct`, replacing this by `class` should allow the project to build \
+  and run again as a temporary workaround.
+
+  If you are not transitioning from `GlobalEnvironment`, you should not have to use this type \
+  at all. It is only provided to help transitioning projects from `GlobalEnvironment` to \
+  `ComposableEnvironment`.
+  """)
+open class GlobalEnvironment: ComposableEnvironment {
+  public required init() {}
+}
+
+@available(*, deprecated, message: """
+  If you are transitioning from `GlobalEnvironment`, you should make sure that is type is a \
+  subclass of `ComposableEnvironment`.
+  
+  If your environment is a `struct`, replacing this by `class` should allow the project to build \
+  and run again as a temporary workaround.
+
+  If you are not transitioning from `GlobalEnvironment`, you should not have to use this type \
+  at all. It is only provided to help transitioning projects from `GlobalEnvironment` to \
+  `ComposableEnvironment`.
+  """)
+open class GlobalDependenciesAccessing: ComposableEnvironment {
+  public required init() {}
+}

--- a/Sources/GlobalEnvironment/Deprecations/ComposableEnvironment+Migration.swift
+++ b/Sources/GlobalEnvironment/Deprecations/ComposableEnvironment+Migration.swift
@@ -1,0 +1,15 @@
+@available(*, deprecated, message: """
+  If you are transitioning from `ComposableEnvironment`, you should replace this class by a type \
+  conforming to `GlobalEnvironment` or `GlobalDependenciesAccessing`. Please make sure that you \
+  are not overriding dependencies mid-chain, as all dependencies are shared globally when using \
+  `GlobalEnvironment`. If your project depends on mid-chain dependencies overrides, using \
+  `GlobalEnvironment` will likely produce incoherent results. In this case, you should continue \
+  using `ComposableEnvironment`.
+  
+  If you are not transitioning from `ComposableEnvironment`, you should not have to use this type \
+  at all. It is only provided to help transitioning projects from `ComposableEnvironment` to \
+  `GlobalEnvironment`.
+  """)
+open class ComposableEnvironment: GlobalEnvironment {
+  public required init() {}
+}


### PR DESCRIPTION
This PR aims to provide contextual information when migrating from `Composable` to `Global` environments (in both ways).
It also helps to get the project back into a buildable, and potentially runnable, state sooner.