### PR TITLE
Deprecate `breakpointOnNil` reducer variants

### DIFF
--- a/Sources/ComposableEnvironment/Deprecations/Reducers+Deprecations.swift
+++ b/Sources/ComposableEnvironment/Deprecations/Reducers+Deprecations.swift
@@ -1,0 +1,70 @@
+// Deprecated after TCA 0.31.0:
+import ComposableArchitecture
+
+@available(
+  *,
+  deprecated,
+  message: "'pullback' no longer takes a 'breakpointOnNil' argument"
+)
+extension Reducer where Environment: ComposableEnvironment {
+  public func pullback<GlobalState, GlobalAction, GlobalEnvironment>(
+    state toLocalState: CasePath<GlobalState, State>,
+    action toLocalAction: CasePath<GlobalAction, Action>,
+    breakpointOnNil: Bool = true,
+    _ file: StaticString = #file,
+    _ line: UInt = #line
+  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
+  where GlobalEnvironment: ComposableEnvironment {
+    let local = Environment()
+    return pullback(
+      state: toLocalState,
+      action: toLocalAction,
+      environment: local.updatingFromParentIfNeeded,
+      breakpointOnNil: breakpointOnNil
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "'forEach' no longer takes a 'breakpointOnNil' argument"
+  )
+  public func forEach<GlobalState, GlobalAction, GlobalEnvironment, ID>(
+    state toLocalState: WritableKeyPath<GlobalState, IdentifiedArray<ID, State>>,
+    action toLocalAction: CasePath<GlobalAction, (ID, Action)>,
+    breakpointOnNil: Bool = true,
+    _ file: StaticString = #file,
+    _ line: UInt = #line
+  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
+  where GlobalEnvironment: ComposableEnvironment {
+    let local = Environment()
+    return forEach(
+      state: toLocalState,
+      action: toLocalAction,
+      environment: local.updatingFromParentIfNeeded,
+      breakpointOnNil: breakpointOnNil
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "'forEach' no longer takes a 'breakpointOnNil' argument"
+  )
+  public func forEach<GlobalState, GlobalAction, GlobalEnvironment, Key>(
+    state toLocalState: WritableKeyPath<GlobalState, [Key: State]>,
+    action toLocalAction: CasePath<GlobalAction, (Key, Action)>,
+    breakpointOnNil: Bool = true,
+    _ file: StaticString = #file,
+    _ line: UInt = #line
+  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
+  where GlobalEnvironment: ComposableEnvironment {
+    let local = Environment()
+    return forEach(
+      state: toLocalState,
+      action: toLocalAction,
+      environment: local.updatingFromParentIfNeeded,
+      breakpointOnNil: breakpointOnNil
+    )
+  }
+}

--- a/Sources/ComposableEnvironment/Reducer+ComposableEnvironment.swift
+++ b/Sources/ComposableEnvironment/Reducer+ComposableEnvironment.swift
@@ -53,7 +53,6 @@ extension Reducer where Environment: ComposableEnvironment {
   public func pullback<GlobalState, GlobalAction, GlobalEnvironment>(
     state toLocalState: CasePath<GlobalState, State>,
     action toLocalAction: CasePath<GlobalAction, Action>,
-    breakpointOnNil: Bool = true,
     _ file: StaticString = #file,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
@@ -62,8 +61,7 @@ extension Reducer where Environment: ComposableEnvironment {
     return pullback(
       state: toLocalState,
       action: toLocalAction,
-      environment: local.updatingFromParentIfNeeded,
-      breakpointOnNil: breakpointOnNil
+      environment: local.updatingFromParentIfNeeded
     )
   }
 
@@ -87,7 +85,6 @@ extension Reducer where Environment: ComposableEnvironment {
   public func forEach<GlobalState, GlobalAction, GlobalEnvironment, ID>(
     state toLocalState: WritableKeyPath<GlobalState, IdentifiedArray<ID, State>>,
     action toLocalAction: CasePath<GlobalAction, (ID, Action)>,
-    breakpointOnNil: Bool = true,
     _ file: StaticString = #file,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
@@ -96,8 +93,7 @@ extension Reducer where Environment: ComposableEnvironment {
     return forEach(
       state: toLocalState,
       action: toLocalAction,
-      environment: local.updatingFromParentIfNeeded,
-      breakpointOnNil: breakpointOnNil
+      environment: local.updatingFromParentIfNeeded
     )
   }
 
@@ -120,7 +116,6 @@ extension Reducer where Environment: ComposableEnvironment {
   public func forEach<GlobalState, GlobalAction, GlobalEnvironment, Key>(
     state toLocalState: WritableKeyPath<GlobalState, [Key: State]>,
     action toLocalAction: CasePath<GlobalAction, (Key, Action)>,
-    breakpointOnNil: Bool = true,
     _ file: StaticString = #file,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment>
@@ -129,8 +124,7 @@ extension Reducer where Environment: ComposableEnvironment {
     return forEach(
       state: toLocalState,
       action: toLocalAction,
-      environment: local.updatingFromParentIfNeeded,
-      breakpointOnNil: breakpointOnNil
+      environment: local.updatingFromParentIfNeeded
     )
   }
 }

--- a/Sources/GlobalEnvironment/Deprecations/Reducers+Deprecations.swift
+++ b/Sources/GlobalEnvironment/Deprecations/Reducers+Deprecations.swift
@@ -1,0 +1,67 @@
+// Deprecated after TCA 0.31.0:
+import ComposableArchitecture
+
+@available(
+  *,
+  deprecated,
+  message: "'pullback' no longer takes a 'breakpointOnNil' argument"
+)
+extension Reducer where Environment: GlobalEnvironment {
+  public func pullback<GlobalState, GlobalAction, GlobalEnvironment>(
+    state toLocalState: CasePath<GlobalState, State>,
+    action toLocalAction: CasePath<GlobalAction, Action>,
+    breakpointOnNil: Bool = true,
+    _ file: StaticString = #file,
+    _ line: UInt = #line
+  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
+    let local = Environment()
+    return pullback(
+      state: toLocalState,
+      action: toLocalAction,
+      environment: { _ in local },
+      breakpointOnNil: breakpointOnNil
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "'forEach' no longer takes a 'breakpointOnNil' argument"
+  )
+  public func forEach<GlobalState, GlobalAction, GlobalEnvironment, ID>(
+    state toLocalState: WritableKeyPath<GlobalState, IdentifiedArray<ID, State>>,
+    action toLocalAction: CasePath<GlobalAction, (ID, Action)>,
+    breakpointOnNil: Bool = true,
+    _ file: StaticString = #file,
+    _ line: UInt = #line
+  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
+    let local = Environment()
+    return forEach(
+      state: toLocalState,
+      action: toLocalAction,
+      environment: { _ in local },
+      breakpointOnNil: breakpointOnNil
+    )
+  }
+
+  @available(
+    *,
+    deprecated,
+    message: "'forEach' no longer takes a 'breakpointOnNil' argument"
+  )
+  public func forEach<GlobalState, GlobalAction, GlobalEnvironment, Key>(
+    state toLocalState: WritableKeyPath<GlobalState, [Key: State]>,
+    action toLocalAction: CasePath<GlobalAction, (Key, Action)>,
+    breakpointOnNil: Bool = true,
+    _ file: StaticString = #file,
+    _ line: UInt = #line
+  ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
+    let local = Environment()
+    return forEach(
+      state: toLocalState,
+      action: toLocalAction,
+      environment: { _ in local },
+      breakpointOnNil: breakpointOnNil
+    )
+  }
+}

--- a/Sources/GlobalEnvironment/Reducer+GlobalEnvironment.swift
+++ b/Sources/GlobalEnvironment/Reducer+GlobalEnvironment.swift
@@ -50,7 +50,6 @@ extension Reducer where Environment: GlobalEnvironment {
   public func pullback<GlobalState, GlobalAction, GlobalEnvironment>(
     state toLocalState: CasePath<GlobalState, State>,
     action toLocalAction: CasePath<GlobalAction, Action>,
-    breakpointOnNil: Bool = true,
     _ file: StaticString = #file,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
@@ -58,8 +57,7 @@ extension Reducer where Environment: GlobalEnvironment {
     return pullback(
       state: toLocalState,
       action: toLocalAction,
-      environment: { _ in local },
-      breakpointOnNil: breakpointOnNil
+      environment: { _ in local }
     )
   }
 
@@ -83,7 +81,6 @@ extension Reducer where Environment: GlobalEnvironment {
   public func forEach<GlobalState, GlobalAction, GlobalEnvironment, ID>(
     state toLocalState: WritableKeyPath<GlobalState, IdentifiedArray<ID, State>>,
     action toLocalAction: CasePath<GlobalAction, (ID, Action)>,
-    breakpointOnNil: Bool = true,
     _ file: StaticString = #file,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
@@ -91,8 +88,7 @@ extension Reducer where Environment: GlobalEnvironment {
     return forEach(
       state: toLocalState,
       action: toLocalAction,
-      environment: { _ in local },
-      breakpointOnNil: breakpointOnNil
+      environment: { _ in local }
     )
   }
 
@@ -115,7 +111,6 @@ extension Reducer where Environment: GlobalEnvironment {
   public func forEach<GlobalState, GlobalAction, GlobalEnvironment, Key>(
     state toLocalState: WritableKeyPath<GlobalState, [Key: State]>,
     action toLocalAction: CasePath<GlobalAction, (Key, Action)>,
-    breakpointOnNil: Bool = true,
     _ file: StaticString = #file,
     _ line: UInt = #line
   ) -> Reducer<GlobalState, GlobalAction, GlobalEnvironment> {
@@ -123,8 +118,7 @@ extension Reducer where Environment: GlobalEnvironment {
     return forEach(
       state: toLocalState,
       action: toLocalAction,
-      environment: { _ in local },
-      breakpointOnNil: breakpointOnNil
+      environment: { _ in local }
     )
   }
 }


### PR DESCRIPTION
These variants are deprecated in TCA 31.0+.