### PR TITLE
Simplifying dependency declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,12 @@ Both modules are defined in the same repository to maintain source compatibility
 **The `GlobalEnvironment` module should fit most of the cases.**
 
 ## Defining dependencies
-Each dependency we want to share should be declared with a `DependencyKey`'s in a similar fashion one declares custom `EnvironmentValue`'s in SwiftUI using `EnvironmentKey`'s. Let define a `mainQueue` dependency:
-```swift
-struct MainQueueKey: DependencyKey {
-  static var defaultValue: AnySchedulerOf<DispatchQueue> { .main }
-}
-```
-This key doesn't need to be public. If the dependency is an existential type, it can be even used as a `DependencyKey` itself, without needing to introduce an additional type.
-
-Like we would do with SwiftUI's `EnvironmentValues`, we also install it in `Dependencies`:
+Each dependency we want to share should be declared via subscript with a `KeyPath` for the dependency. Let define a `mainQueue` dependency:
 ```swift
 extension Dependencies {
   var mainQueue: AnySchedulerOf<DispatchQueue> {
-    get { self[MainQueueKey.self] }
-    set { self[MainQueueKey.self] = newValue }
+    get { self[\.mainQueue] ?? .main }
+    set { self[\.mainQueue] = newValue }
   }
 }
 ```
@@ -170,7 +162,7 @@ The principal differences between the two approaches are summarized in the follo
 In order to ease its learning curve, the library bases its API on SwiftUI's Environment. We have the following functional correspondences:
 | SwiftUI | ComposableEnvironment| Usage |
 |---|---|---|
-|`EnvironmentKey`|`DependencyKey`| Identify a shared value |
+|`EnvironmentKey`|`DependencyKey`| Identify a shared value, deprecated |
 |`EnvironmentValues`|`Dependencies`| Expose a shared value |
 |`@Environment`|`@Dependency`| Retrieve a shared value |
 |`View`|`(Composable/Global)Environment`| A node |

--- a/Sources/_Dependencies/Dependencies.swift
+++ b/Sources/_Dependencies/Dependencies.swift
@@ -1,7 +1,7 @@
 /// This type acts as a namespace to reference your dependencies.
 ///
 /// To declare a dependency,  declare a computed property in this
-/// type. For example, if
+/// type. For example:
 /// ```swift
 /// extension Dependencies {
 ///   var uuidGenerator: () -> UUID {
@@ -46,7 +46,7 @@ public struct Dependencies {
 
   fileprivate init() {}
 	
-	public subscript<T>(_ keyPath: WritableKeyPath<Dependencies, T>) -> T? {
+  public subscript<T>(_ keyPath: WritableKeyPath<Dependencies, T>) -> T? {
     get { values[keyPath]?.value as? T }
     set { values[keyPath] = newValue.map { .defined($0) } }
 	}

--- a/Sources/_Dependencies/Dependencies.swift
+++ b/Sources/_Dependencies/Dependencies.swift
@@ -1,13 +1,12 @@
 /// This type acts as a namespace to reference your dependencies.
 ///
-/// To declare a dependency, create a ``DependencyKey``, and declare a computed property in this
-/// type like you would declare a custom `EnvironmentValue` in SwiftUI. For example, if
-/// `UUIDGeneratorKey` is a ``DependencyKey`` with ``DependencyKey/Value`` == `() -> UUID`:
+/// To declare a dependency,  declare a computed property in this
+/// type. For example, if
 /// ```swift
 /// extension Dependencies {
 ///   var uuidGenerator: () -> UUID {
-///     get { self[UUIDGeneratorKey.self] }
-///     set { self[UUIDGeneratorKey.self] = newValue }
+///     get { self[\.uuidGenerator] ?? { UUID() } }
+///     set { self[\.uuidGenerator] = newValue }
 ///   }
 /// }
 /// ```
@@ -42,13 +41,26 @@ public struct Dependencies {
     }
   }
 
-  fileprivate var values = [ObjectIdentifier: DependencyValue]()
+  fileprivate var deprecatedValues = [ObjectIdentifier: DependencyValue]()
+	fileprivate var values = [PartialKeyPath<Dependencies>: DependencyValue]()
 
   fileprivate init() {}
-
+	
+	public subscript<T>(_ keyPath: WritableKeyPath<Dependencies, T>) -> T? {
+		get { values[keyPath]?.value as? T }
+		set { values[keyPath] = newValue.map { .defined($0) } }
+	}
+	
+	@available(
+		*, deprecated,
+		 message:
+"""
+`DependencyKey` is deprecated, use keypathes instead
+"""
+	)
   public subscript<T>(_ key: T.Type) -> T.Value where T: DependencyKey {
-    get { values[ObjectIdentifier(key)]?.value as? T.Value ?? key.defaultValue }
-    set { values[ObjectIdentifier(key)] = .defined(newValue) }
+    get { deprecatedValues[ObjectIdentifier(key)]?.value as? T.Value ?? key.defaultValue }
+    set { deprecatedValues[ObjectIdentifier(key)] = .defined(newValue) }
   }
 }
 

--- a/Sources/_Dependencies/Dependencies.swift
+++ b/Sources/_Dependencies/Dependencies.swift
@@ -47,13 +47,13 @@ public struct Dependencies {
   fileprivate init() {}
 	
 	public subscript<T>(_ keyPath: WritableKeyPath<Dependencies, T>) -> T? {
-		get { values[keyPath]?.value as? T }
-		set { values[keyPath] = newValue.map { .defined($0) } }
+    get { values[keyPath]?.value as? T }
+    set { values[keyPath] = newValue.map { .defined($0) } }
 	}
 	
 	@available(
-		*, deprecated,
-		 message:
+    *, deprecated,
+     message:
 """
 `DependencyKey` is deprecated, use keypathes instead
 """

--- a/Sources/_Dependencies/DependencyKey.swift
+++ b/Sources/_Dependencies/DependencyKey.swift
@@ -3,6 +3,13 @@
 ///
 /// You use this protocol like `EnvironmentKey` are used in SwiftUI. Types conforming to this
 /// protocol can then be used to declare the dependency in the ``Dependencies`` namespace.
+@available(
+	*, deprecated,
+	 message:
+"""
+`DependencyKey` is deprecated, use keypathes instead
+"""
+)
 public protocol DependencyKey {
   associatedtype Value
   /// The default value returned when accessing the corresponding dependency when no value was

--- a/Tests/ComposableEnvironmentTests/ComposableEnvironmentTests.swift
+++ b/Tests/ComposableEnvironmentTests/ComposableEnvironmentTests.swift
@@ -2,32 +2,20 @@ import XCTest
 
 @testable import ComposableEnvironment
 
-private struct IntKey: DependencyKey {
-  static var defaultValue: Int { 1 }
-}
-
-private struct Int1Key: DependencyKey {
-  static var defaultValue: Int { -1 }
-}
-
-private struct Int2Key: DependencyKey {
-  static var defaultValue: Int { -10 }
-}
-
 extension Dependencies {
   fileprivate var int: Int {
-    get { self[IntKey.self] }
-    set { self[IntKey.self] = newValue }
+		get { self[\.int] ?? 1 }
+		set { self[\.int] = newValue }
   }
 
   fileprivate var int1: Int {
-    get { self[Int1Key.self] }
-    set { self[Int1Key.self] = newValue }
+		get { self[\.int1] ?? -1 }
+		set { self[\.int1] = newValue }
   }
 
   fileprivate var int2: Int {
-    get { self[Int2Key.self] }
-    set { self[Int2Key.self] = newValue }
+		get { self[\.int2] ?? -10 }
+		set { self[\.int2] = newValue }
   }
 }
 

--- a/Tests/ComposableEnvironmentTests/ComposableEnvironmentTests.swift
+++ b/Tests/ComposableEnvironmentTests/ComposableEnvironmentTests.swift
@@ -4,18 +4,18 @@ import XCTest
 
 extension Dependencies {
   fileprivate var int: Int {
-		get { self[\.int] ?? 1 }
-		set { self[\.int] = newValue }
+    get { self[\.int] ?? 1 }
+    set { self[\.int] = newValue }
   }
 
   fileprivate var int1: Int {
-		get { self[\.int1] ?? -1 }
-		set { self[\.int1] = newValue }
+    get { self[\.int1] ?? -1 }
+    set { self[\.int1] = newValue }
   }
 
   fileprivate var int2: Int {
-		get { self[\.int2] ?? -10 }
-		set { self[\.int2] = newValue }
+    get { self[\.int2] ?? -10 }
+    set { self[\.int2] = newValue }
   }
 }
 

--- a/Tests/ComposableEnvironmentTests/ReducerComposableEnvironmentTests.swift
+++ b/Tests/ComposableEnvironmentTests/ReducerComposableEnvironmentTests.swift
@@ -6,8 +6,8 @@ import XCTest
 
 extension Dependencies {
   fileprivate var int: Int {
-    get { self[.int] }
-    set { self[.int] = newValue }
+    get { self[\.int] }
+    set { self[\.int] = newValue }
   }
 }
 

--- a/Tests/ComposableEnvironmentTests/ReducerComposableEnvironmentTests.swift
+++ b/Tests/ComposableEnvironmentTests/ReducerComposableEnvironmentTests.swift
@@ -4,14 +4,10 @@ import XCTest
 
 @testable import ComposableEnvironment
 
-private struct IntKey: DependencyKey {
-  static var defaultValue: Int { 1 }
-}
-
 extension Dependencies {
   fileprivate var int: Int {
-    get { self[IntKey.self] }
-    set { self[IntKey.self] = newValue }
+    get { self[.int] }
+    set { self[.int] = newValue }
   }
 }
 

--- a/Tests/GlobalEnvironmentTests/GlobalEnvironmentTests.swift
+++ b/Tests/GlobalEnvironmentTests/GlobalEnvironmentTests.swift
@@ -3,32 +3,20 @@ import _Dependencies
 
 @testable import GlobalEnvironment
 
-private struct IntKey: DependencyKey {
-  static var defaultValue: Int { 1 }
-}
-
-private struct Int1Key: DependencyKey {
-  static var defaultValue: Int { -1 }
-}
-
-private struct Int2Key: DependencyKey {
-  static var defaultValue: Int { -10 }
-}
-
 extension Dependencies {
   fileprivate var int: Int {
-    get { self[IntKey.self] }
-    set { self[IntKey.self] = newValue }
+    get { self[\.int] ?? 1 }
+    set { self[\.int] = newValue }
   }
 
   fileprivate var int1: Int {
-    get { self[Int1Key.self] }
-    set { self[Int1Key.self] = newValue }
+    get { self[\.int1] ?? -1 }
+    set { self[\.int1] = newValue }
   }
 
   fileprivate var int2: Int {
-    get { self[Int2Key.self] }
-    set { self[Int2Key.self] = newValue }
+    get { self[\.int2] ?? -10 }
+    set { self[\.int2] = newValue }
   }
 }
 

--- a/Tests/GlobalEnvironmentTests/ReducerGlobalEnvironmentTests.swift
+++ b/Tests/GlobalEnvironmentTests/ReducerGlobalEnvironmentTests.swift
@@ -10,8 +10,8 @@ private struct IntKey: DependencyKey {
 
 extension Dependencies {
   fileprivate var int: Int {
-    get { self[IntKey.self] }
-    set { self[IntKey.self] = newValue }
+		get { self[\.int] ?? 1 }
+		set { self[\.int] = newValue }
   }
 }
 

--- a/Tests/GlobalEnvironmentTests/ReducerGlobalEnvironmentTests.swift
+++ b/Tests/GlobalEnvironmentTests/ReducerGlobalEnvironmentTests.swift
@@ -10,8 +10,8 @@ private struct IntKey: DependencyKey {
 
 extension Dependencies {
   fileprivate var int: Int {
-		get { self[\.int] ?? 1 }
-		set { self[\.int] = newValue }
+    get { self[\.int] ?? 1 }
+    set { self[\.int] = newValue }
   }
 }
 


### PR DESCRIPTION
Dependency declaration via `DependencyKey` is overcomplicated and requires too many lines of code for one property.
I suggest to simplify it and use `KeyPath` itself instead of `DependencyKey`.
Example:
```swift
extension Dependencies {
    public var exampleInt: Int {
        get { self[\.exampleInt] ?? 0 }
        set { self[\.exampleInt] = newValue }
    }
}
```