### PR TITLE
Add typealiases for `@Dependency` and `DependencyKey`

### DIFF
--- a/Sources/ComposableDependencies/ComposableDependencies.swift
+++ b/Sources/ComposableDependencies/ComposableDependencies.swift
@@ -3,3 +3,7 @@
 
 @available(*, deprecated, renamed: "Dependencies")
 public typealias ComposableDependencies = Dependencies
+
+/// This namespace is used to provide non-clashing variants to the `DependencyKey` protocol and the
+/// `@Dependency` property wrapper.
+public enum Compatible {}

--- a/Sources/ComposableEnvironment/ComposableEnvironment.swift
+++ b/Sources/ComposableEnvironment/ComposableEnvironment.swift
@@ -176,6 +176,17 @@ extension Dependencies {
   }
 }
 
-/// You can use this typealias if `@DependencyKey` is clashing with other modules offering
-/// a similarly named protocol.
-public typealias ComposableDependencyKey = DependencyKey
+extension Compatible {
+  /// You can use this typealias if `DependencyKey` is clashing with other modules offering
+  /// a similarly named protocol.
+  ///
+  /// You should be able to replace:
+  /// ```swift
+  /// struct MainQueueKey: DependencyKey { … }
+  /// ```
+  /// by
+  /// ```swift
+  /// struct MainQueueKey: Compatible.DependencyKey { … }
+  /// ```
+  public typealias DependencyKey = _Dependencies.DependencyKey
+}

--- a/Sources/ComposableEnvironment/ComposableEnvironment.swift
+++ b/Sources/ComposableEnvironment/ComposableEnvironment.swift
@@ -175,3 +175,7 @@ extension Dependencies {
     ComposableEnvironment.aliases.clear()
   }
 }
+
+/// You can use this typealias if `@DependencyKey` is clashing with other modules offering
+/// a similarly named protocol.
+public typealias ComposableDependencyKey = DependencyKey

--- a/Sources/ComposableEnvironment/Dependency.swift
+++ b/Sources/ComposableEnvironment/Dependency.swift
@@ -70,3 +70,7 @@ public struct Dependency<Value> {
     set { fatalError() }
   }
 }
+
+/// You can use this typealias if `@Dependency` is clashing with other modules offering
+/// similarly named property wrappers
+public typealias ComposableDependency = Dependency

--- a/Sources/ComposableEnvironment/Dependency.swift
+++ b/Sources/ComposableEnvironment/Dependency.swift
@@ -72,5 +72,5 @@ public struct Dependency<Value> {
 }
 
 /// You can use this typealias if `@Dependency` is clashing with other modules offering
-/// similarly named property wrappers
+/// a similarly named property wrapper
 public typealias ComposableDependency = Dependency

--- a/Sources/ComposableEnvironment/Dependency.swift
+++ b/Sources/ComposableEnvironment/Dependency.swift
@@ -71,6 +71,20 @@ public struct Dependency<Value> {
   }
 }
 
-/// You can use this typealias if `@Dependency` is clashing with other modules offering
-/// a similarly named property wrapper
-public typealias ComposableDependency = Dependency
+/// Convenience typealias in case of name clashes. See ``Compatible.Dependency``.
+public typealias ComposableEnvironmentDependency = Dependency
+
+extension Compatible {
+  /// You can use this typealias if `@Dependency` is clashing with other modules offering
+  /// a similarly named property wrapper.
+  ///
+  /// You should be able to replace
+  /// ```swift
+  /// @Dependency(\.mainQueue) var mainQueue
+  /// ```
+  /// by
+  /// ```swift
+  /// @Compatible.Dependency(\.mainQueue) var mainQueue
+  /// ```
+  public typealias Dependency = ComposableEnvironmentDependency
+}

--- a/Sources/GlobalEnvironment/Dependency.swift
+++ b/Sources/GlobalEnvironment/Dependency.swift
@@ -36,6 +36,20 @@ public struct Dependency<Value> {
   }
 }
 
-/// You can use this typealias if `@Dependency` is clashing with other modules offering
-/// a similarly named property wrapper
-public typealias GlobalDependency = Dependency
+/// Convenience typealias in case of name clashes. See ``Compatible.Dependency``.
+public typealias ComposableEnvironmentDependency = Dependency
+
+extension Compatible {
+  /// You can use this typealias if `@Dependency` is clashing with other modules offering
+  /// a similarly named property wrapper.
+  ///
+  /// You should be able to replace
+  /// ```swift
+  /// @Dependency(\.mainQueue) var mainQueue
+  /// ```
+  /// by
+  /// ```swift
+  /// @Compatible.Dependency(\.mainQueue) var mainQueue
+  /// ```
+  public typealias Dependency = ComposableEnvironmentDependency
+}

--- a/Sources/GlobalEnvironment/Dependency.swift
+++ b/Sources/GlobalEnvironment/Dependency.swift
@@ -35,3 +35,7 @@ public struct Dependency<Value> {
     Dependencies.global[keyPath: Dependencies.aliases.standardAlias(for: keyPath)]
   }
 }
+
+/// You can use this typealias if `@Dependency` is clashing with other modules offering
+/// similarly named property wrappers
+public typealias GlobalDependency = Dependency

--- a/Sources/GlobalEnvironment/Dependency.swift
+++ b/Sources/GlobalEnvironment/Dependency.swift
@@ -37,5 +37,5 @@ public struct Dependency<Value> {
 }
 
 /// You can use this typealias if `@Dependency` is clashing with other modules offering
-/// similarly named property wrappers
+/// a similarly named property wrapper
 public typealias GlobalDependency = Dependency

--- a/Sources/GlobalEnvironment/GlobalEnvironment.swift
+++ b/Sources/GlobalEnvironment/GlobalEnvironment.swift
@@ -155,6 +155,18 @@ extension Dependencies {
   }
 }
 
-/// You can use this typealias if `@DependencyKey` is clashing with other modules offering
-/// a similarly named protocol.
-public typealias ComposableDependencyKey = DependencyKey
+extension Compatible {
+  /// You can use this typealias if `DependencyKey` is clashing with other modules offering
+  /// a similarly named protocol.
+  ///
+  /// You should be able to replace:
+  /// ```swift
+  /// struct MainQueueKey: DependencyKey { … }
+  /// ```
+  /// by
+  /// ```swift
+  /// struct MainQueueKey: Compatible.DependencyKey { … }
+  /// ```
+  public typealias DependencyKey = _Dependencies.DependencyKey
+}
+

--- a/Sources/GlobalEnvironment/GlobalEnvironment.swift
+++ b/Sources/GlobalEnvironment/GlobalEnvironment.swift
@@ -154,3 +154,7 @@ extension Dependencies {
     Dependencies.global = DependenciesUtilities.new()
   }
 }
+
+/// You can use this typealias if `@DependencyKey` is clashing with other modules offering
+/// a similarly named protocol.
+public typealias ComposableDependencyKey = DependencyKey

--- a/Sources/_Dependencies/DependencyKey.swift
+++ b/Sources/_Dependencies/DependencyKey.swift
@@ -9,7 +9,3 @@ public protocol DependencyKey {
   /// defined by one of its parents.
   static var defaultValue: Self.Value { get }
 }
-
-/// You can use this typealias if `@DependencyKey` is clashing with other modules offering
-/// a similarly named protocol.
-public typealias ComposableDependencyKey = DependencyKey

--- a/Sources/_Dependencies/DependencyKey.swift
+++ b/Sources/_Dependencies/DependencyKey.swift
@@ -9,3 +9,7 @@ public protocol DependencyKey {
   /// defined by one of its parents.
   static var defaultValue: Self.Value { get }
 }
+
+/// You can use this typealias if `@DependencyKey` is clashing with other modules offering
+/// similarly named protocols
+public typealias ComposableDependencyKey

--- a/Sources/_Dependencies/DependencyKey.swift
+++ b/Sources/_Dependencies/DependencyKey.swift
@@ -11,5 +11,5 @@ public protocol DependencyKey {
 }
 
 /// You can use this typealias if `@DependencyKey` is clashing with other modules offering
-/// similarly named protocols
+/// a similarly named protocol.
 public typealias ComposableDependencyKey = DependencyKey

--- a/Sources/_Dependencies/DependencyKey.swift
+++ b/Sources/_Dependencies/DependencyKey.swift
@@ -12,4 +12,4 @@ public protocol DependencyKey {
 
 /// You can use this typealias if `@DependencyKey` is clashing with other modules offering
 /// similarly named protocols
-public typealias ComposableDependencyKey
+public typealias ComposableDependencyKey = DependencyKey


### PR DESCRIPTION
This allows to use `@Compatible.Dependency` and `Compatible.DependencyKey` as alternative names when migrating to reducer protocols.